### PR TITLE
Edit run.sh to abide by more Shell best practices

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,42 +7,39 @@ if [ -n "${OAP_DEBUG:-}" ] ; then
 fi
 
 #set the max memory
-BYTES_PER_MEG=$((1024*1024))
-BYTES_PER_GIG=$((1024*$BYTES_PER_MEG))
+BYTES_PER_MEG="$((1024 * 1024))"
+BYTES_PER_GIG="$((1024 * BYTES_PER_MEG))"
 
-DEFAULT_MIN=$((64 * $BYTES_PER_MEG)) #This is a guess
-regex='^([[:digit:]]+)([GgMm])?i?$'
-num_regex='^[[:digit:]]+'
-unit_regex='[GgMm]'
+DEFAULT_MIN="$((64 * BYTES_PER_MEG))" #This is a guess
 
 export NODE_OPTIONS=""
 
-if [ 1 -eq $(echo "${OCP_AUTH_PROXY_MEMORY_LIMIT:-}" | grep -Ec $regex) ] ; then
-    num=$(echo $OCP_AUTH_PROXY_MEMORY_LIMIT | grep -oE $num_regex)
-    unit=$(echo $OCP_AUTH_PROXY_MEMORY_LIMIT | grep -oE $unit_regex || echo "")
+if echo "${OCP_AUTH_PROXY_MEMORY_LIMIT:-}" | grep -qE "^([[:digit:]]+)([GgMm])?i?$"; then
+    num="$(echo "${OCP_AUTH_PROXY_MEMORY_LIMIT}" | grep -oE "^[[:digit:]]+")"
+    unit="$(echo "${OCP_AUTH_PROXY_MEMORY_LIMIT}" | grep -oE "[GgMm]" || echo "")"
 
-    if [ "$unit" = "G" ] || [ "$unit" = "g" ]; then
-        num="$((num * $BYTES_PER_GIG))" # enables math to work out for odd Gi
-    elif [ "$unit" = "M" ]  || [ "$unit" = "m" ]; then
-        num="$((num * $BYTES_PER_MEG))" # enables math to work out for odd Gi
+    if [ "${unit}" = "G" ] || [ "${unit}" = "g" ]; then
+        num="$((num * BYTES_PER_GIG))" # enables math to work out for odd Gi
+    elif [ "${unit}" = "M" ]  || [ "${unit}" = "m" ]; then
+        num="$((num * BYTES_PER_MEG))" # enables math to work out for odd Gi
     #else assume bytes
     fi
 
-    if [ $num -lt $DEFAULT_MIN ] ; then
-        echo "$num is less than the default $(($DEFAULT_MIN / $BYTES_PER_MEG))m.  Setting to default."
-        num=$DEFAULT_MIN
+    if [ ${num} -lt ${DEFAULT_MIN} ] ; then
+        echo "${num} is less than the default $((DEFAULT_MIN / BYTES_PER_MEG))m.  Setting to default."
+        num="${DEFAULT_MIN}"
     fi
 
-    export NODE_OPTIONS="--max-old-space-size=$((num / $BYTES_PER_MEG))"
-
+    NODE_OPTIONS="--max-old-space-size=$((num / BYTES_PER_MEG))"
+    export NODE_OPTIONS
 else
     echo "Unable to process the OCP_AUTH_PROXY_MEMORY_LIMIT: '${OCP_AUTH_PROXY_MEMORY_LIMIT}'."
     echo "It must be a number, optionally followed by 'G'(Gigabytes) or 'M' (Megabytes), e.g. 64M"
     exit 1
 fi
 
-cd ${APP_DIR}
-echo "Using NODE_OPTIONS: '$NODE_OPTIONS' Memory setting is in MB"
+cd "${APP_DIR}"
+echo "Using NODE_OPTIONS: '${NODE_OPTIONS}' Memory setting is in MB"
 echo "Running from directory: '$(pwd)'"
 
 exec node ${NODE_OPTIONS} /usr/local/bin/npm start


### PR DESCRIPTION
This commit edits the shell code in `run.sh` to abide by the following
best practices:

 - don't use `${}` for variable expansions inside of the arithmetic
   shell `$(( ))`
 - always use `${}` for variable expansions outside of that context
 - always quote veriables and expansions unless globbing or word
   splitting is expressly required, as in with `exec`
 - check for the return code of commands with `if` statements instead of
   checking by proxy with text output

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>